### PR TITLE
v5.0.0 - Adds force_destroy bool, defaults to false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-ffabc051eca8cebec6ee297851e01726f0701bc0
+      - image: trussworks/circleci-docker-primary:tf12-7552e0866ce831fb2e2459ddc1faa1017267c402
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,19 +12,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.21.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
+    rev: v1.22.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.21.0
+    rev: v1.22.2
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run --verbose
-        verbose: true
+

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Terraform 0.11. Pin module version to ~> 3.5.0. Submit pull-requests to terrafor
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | string | `"true"` | no |
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | list(string) | `[]` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | string | `"elb"` | no |
+| force\_destroy | A bool that indicates all objects \(including any locked objects\) should be deleted from the bucket so the bucket can be destroyed without error. | bool | `"false"` | no |
 | nlb\_accounts | List of accounts for NLB logs.  By default limits to the current account. | list(string) | `[]` | no |
 | nlb\_logs\_prefix | S3 prefix for NLB logs. | string | `"nlb"` | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `"redshift"` | no |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Terraform 0.11. Pin module version to ~> 3.5.0. Submit pull-requests to terrafor
 | cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `"cloudwatch"` | no |
 | config\_accounts | List of accounts for Config logs.  By default limits to the current account. | list(string) | `[]` | no |
 | config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `"config"` | no |
-| create\_public\_access\_block | Whether to create a public_access_block restricting public access to the bucket. | string | `"true"` | no |
+| create\_public\_access\_block | Whether to create a public\_access\_block restricting public access to the bucket. | string | `"true"` | no |
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | string | `"true"` | no |
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | list(string) | `[]` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | string | `"elb"` | no |
@@ -112,7 +112,7 @@ Terraform 0.11. Pin module version to ~> 3.5.0. Submit pull-requests to terrafor
 | nlb\_logs\_prefix | S3 prefix for NLB logs. | string | `"nlb"` | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `"redshift"` | no |
 | region | Region where the AWS S3 bucket will be created. | string | n/a | yes |
-| s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) list. | string | `"log-delivery-write"` | no |
+| s3\_bucket\_acl | Set bucket ACL per \[AWS S3 Canned ACL\]\(<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>\) list. | string | `"log-delivery-write"` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | string | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | string | `"90"` | no |
 

--- a/examples/alb/main.tf
+++ b/examples/alb/main.tf
@@ -3,6 +3,7 @@ module "aws_logs" {
   s3_bucket_name = var.test_name
   region         = var.region
   allow_alb      = "true"
+  force_destroy  = var.force_destroy
 }
 
 resource "aws_lb" "test_lb" {

--- a/examples/alb/variables.tf
+++ b/examples/alb/variables.tf
@@ -9,3 +9,8 @@ variable "region" {
 variable "vpc_azs" {
   type = list(string)
 }
+
+variable "force_destroy" {
+  type = bool
+}
+

--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -2,6 +2,7 @@ module "aws_logs" {
   source         = "../../"
   s3_bucket_name = var.test_name
   region         = var.region
+  force_destroy  = var.force_destroy
 }
 
 module "aws_cloudtrail" {

--- a/examples/cloudtrail/variables.tf
+++ b/examples/cloudtrail/variables.tf
@@ -5,3 +5,7 @@ variable "test_name" {
 variable "region" {
   type = string
 }
+
+variable "force_destroy" {
+  type = bool
+}

--- a/examples/combined/main.tf
+++ b/examples/combined/main.tf
@@ -2,6 +2,7 @@ module "aws_logs" {
   source         = "../../"
   s3_bucket_name = var.test_name
   region         = var.region
+  force_destroy  = var.force_destroy
 }
 
 resource "aws_lb" "test_alb" {
@@ -80,8 +81,9 @@ resource "aws_redshift_cluster" "test_redshift" {
 }
 
 resource "aws_s3_bucket" "log_source_bucket" {
-  bucket = "${var.test_name}-source"
-  acl    = "private"
+  bucket        = "${var.test_name}-source"
+  acl           = "private"
+  force_destroy = var.force_destroy
 
   logging {
     target_bucket = module.aws_logs.aws_logs_bucket

--- a/examples/combined/variables.tf
+++ b/examples/combined/variables.tf
@@ -14,3 +14,7 @@ variable "test_redshift" {
   type    = bool
   default = true
 }
+
+variable "force_destroy" {
+  type = bool
+}

--- a/examples/config/main.tf
+++ b/examples/config/main.tf
@@ -4,6 +4,7 @@ module "aws_logs" {
   region             = var.region
   allow_config       = "true"
   config_logs_prefix = "config"
+  force_destroy      = var.force_destroy
 }
 
 module "config" {

--- a/examples/config/variables.tf
+++ b/examples/config/variables.tf
@@ -1,7 +1,12 @@
 variable "test_name" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type = "string"
+  type = string
 }
+
+variable "force_destroy" {
+  type = bool
+}
+

--- a/examples/elb/main.tf
+++ b/examples/elb/main.tf
@@ -3,6 +3,7 @@ module "aws_logs" {
   s3_bucket_name = var.test_name
   region         = var.region
   allow_elb      = "true"
+  force_destroy  = var.force_destroy
 }
 
 resource "aws_elb" "test_elb" {

--- a/examples/elb/variables.tf
+++ b/examples/elb/variables.tf
@@ -9,3 +9,8 @@ variable "region" {
 variable "vpc_azs" {
   type = list(string)
 }
+
+variable "force_destroy" {
+  type = bool
+}
+

--- a/examples/nlb/main.tf
+++ b/examples/nlb/main.tf
@@ -3,6 +3,7 @@ module "aws_logs" {
   s3_bucket_name = var.test_name
   region         = var.region
   allow_nlb      = "true"
+  force_destroy  = var.force_destroy
 }
 
 resource "aws_lb" "test_lb" {

--- a/examples/nlb/variables.tf
+++ b/examples/nlb/variables.tf
@@ -9,3 +9,7 @@ variable "region" {
 variable "vpc_azs" {
   type = list(string)
 }
+
+variable "force_destroy" {
+  type = bool
+}

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -2,6 +2,7 @@ module "aws_logs" {
   source         = "../../"
   s3_bucket_name = var.test_name
   region         = var.region
+  force_destroy  = var.force_destroy
 }
 
 resource "aws_s3_bucket" "log_source_bucket" {

--- a/examples/s3/variables.tf
+++ b/examples/s3/variables.tf
@@ -5,3 +5,8 @@ variable "test_name" {
 variable "region" {
   type = string
 }
+
+variable "force_destroy" {
+  type = bool
+}
+

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -2,4 +2,5 @@ module "aws_logs" {
   source         = "../../"
   s3_bucket_name = var.test_name
   region         = var.region
+  force_destroy  = var.force_destroy
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -5,3 +5,8 @@ variable "test_name" {
 variable "region" {
   type = string
 }
+
+variable "force_destroy" {
+  type = bool
+}
+

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/trussworks/terraform-aws-logs
 
 go 1.13
 
-require github.com/gruntwork-io/terratest v0.23.0
+require github.com/gruntwork-io/terratest v0.23.3

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gruntwork-io/gruntwork-cli v0.5.1/go.mod h1:IBX21bESC1/LGoV7jhXKUnTQTZgQ6dYRsoj/VqxUSZQ=
-github.com/gruntwork-io/terratest v0.22.2 h1:rIuiDbe5Ur+EYePWtqtzsdXojUfJECXdD92hQRKY5sk=
-github.com/gruntwork-io/terratest v0.22.2/go.mod h1:veL2PxiS2Z5S63ERnyiIY/sxgmXJpZD8YZybiqvduwQ=
-github.com/gruntwork-io/terratest v0.22.3 h1:MReIa0Fz/BYe31A9SlCO9SIarO2pWNjlcDed6JAZASo=
-github.com/gruntwork-io/terratest v0.22.3/go.mod h1:veL2PxiS2Z5S63ERnyiIY/sxgmXJpZD8YZybiqvduwQ=
 github.com/gruntwork-io/terratest v0.23.0 h1:JmGeqO0r5zRLAV55T67NEmPZArz9lN3RKd0moAKhIT4=
 github.com/gruntwork-io/terratest v0.23.0/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -107,7 +103,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -146,8 +141,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 h1:Hynbrlo6LbYI3H1IqXpkVDOcX/3HiPdhVEuyj5a59RM=
 golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:Fecb
 github.com/gruntwork-io/gruntwork-cli v0.5.1/go.mod h1:IBX21bESC1/LGoV7jhXKUnTQTZgQ6dYRsoj/VqxUSZQ=
 github.com/gruntwork-io/terratest v0.23.0 h1:JmGeqO0r5zRLAV55T67NEmPZArz9lN3RKd0moAKhIT4=
 github.com/gruntwork-io/terratest v0.23.0/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
+github.com/gruntwork-io/terratest v0.23.3 h1:zf3K7Z2g88yMgiZiJja5vAWsig8tRqG537Mp9S+qrFc=
+github.com/gruntwork-io/terratest v0.23.3/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/main.tf
+++ b/main.tf
@@ -358,10 +358,11 @@ JSON
 }
 
 resource "aws_s3_bucket" "aws_logs" {
-  bucket = var.s3_bucket_name
-  acl    = var.s3_bucket_acl
-  region = var.region
-  policy = data.template_file.bucket_policy.rendered
+  bucket        = var.s3_bucket_name
+  acl           = var.s3_bucket_acl
+  region        = var.region
+  policy        = data.template_file.bucket_policy.rendered
+  force_destroy = var.force_destroy
 
   lifecycle_rule {
     id      = "expire_all_logs"

--- a/test/terraform_aws_logs_alb_test.go
+++ b/test/terraform_aws_logs_alb_test.go
@@ -20,9 +20,10 @@ func TestTerraformAwsLogsAlb(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/alb/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"vpc_azs":   vpcAzs,
-			"test_name": testName,
+			"region":        awsRegion,
+			"vpc_azs":       vpcAzs,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -30,7 +31,5 @@ func TestTerraformAwsLogsAlb(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty logs_bucket before terraform destroy
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_cloudtrail_test.go
+++ b/test/terraform_aws_logs_cloudtrail_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
@@ -31,7 +30,5 @@ func TestTerraformAwsLogsCloudtrail(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty and delete logs_bucket before terraform destroy
-	defer aws.DeleteS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_cloudtrail_test.go
+++ b/test/terraform_aws_logs_cloudtrail_test.go
@@ -21,8 +21,9 @@ func TestTerraformAwsLogsCloudtrail(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/cloudtrail/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"test_name": testName,
+			"region":        awsRegion,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -32,6 +33,5 @@ func TestTerraformAwsLogsCloudtrail(t *testing.T) {
 	defer terraform.Destroy(t, terraformOptions)
 	// Empty and delete logs_bucket before terraform destroy
 	defer aws.DeleteS3Bucket(t, awsRegion, testName)
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_combined_test.go
+++ b/test/terraform_aws_logs_combined_test.go
@@ -27,6 +27,7 @@ func TestTerraformAwsLogsCombined(t *testing.T) {
 			"vpc_azs":       vpcAzs,
 			"test_name":     testName,
 			"test_redshift": testRedshift,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -36,6 +37,5 @@ func TestTerraformAwsLogsCombined(t *testing.T) {
 	defer terraform.Destroy(t, terraformOptions)
 	// Empty and delete logs_bucket before terraform destroy
 	defer aws.DeleteS3Bucket(t, awsRegion, testName)
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_combined_test.go
+++ b/test/terraform_aws_logs_combined_test.go
@@ -35,7 +35,5 @@ func TestTerraformAwsLogsCombined(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty and delete logs_bucket before terraform destroy
-	defer aws.DeleteS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_config_test.go
+++ b/test/terraform_aws_logs_config_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
@@ -31,8 +30,5 @@ func TestTerraformAwsLogsConfig(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty and delete logs_bucket before terraform destroy
-	defer aws.DeleteS3Bucket(t, awsRegion, testName)
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_config_test.go
+++ b/test/terraform_aws_logs_config_test.go
@@ -21,8 +21,9 @@ func TestTerraformAwsLogsConfig(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/config/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"test_name": testName,
+			"region":        awsRegion,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,

--- a/test/terraform_aws_logs_elb_test.go
+++ b/test/terraform_aws_logs_elb_test.go
@@ -20,9 +20,10 @@ func TestTerraformAwsLogsElb(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/elb/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"vpc_azs":   vpcAzs,
-			"test_name": testName,
+			"region":        awsRegion,
+			"vpc_azs":       vpcAzs,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -30,7 +31,5 @@ func TestTerraformAwsLogsElb(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty logs_bucket before terraform destroy
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_nlb_test.go
+++ b/test/terraform_aws_logs_nlb_test.go
@@ -20,9 +20,10 @@ func TestTerraformAwsLogsNlb(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/nlb/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"vpc_azs":   vpcAzs,
-			"test_name": testName,
+			"region":        awsRegion,
+			"vpc_azs":       vpcAzs,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -30,7 +31,5 @@ func TestTerraformAwsLogsNlb(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty logs_bucket before terraform destroy
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_redshift_test.go
+++ b/test/terraform_aws_logs_redshift_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
@@ -23,8 +22,9 @@ func TestTerraformAwsLogsRedshift(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/redshift/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"test_name": testName,
+			"region":        awsRegion,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -32,7 +32,5 @@ func TestTerraformAwsLogsRedshift(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty logs_bucket before terraform destroy
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_s3_test.go
+++ b/test/terraform_aws_logs_s3_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
@@ -19,8 +18,9 @@ func TestTerraformAwsLogsS3(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/s3/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"test_name": testName,
+			"region":        awsRegion,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -28,7 +28,5 @@ func TestTerraformAwsLogsS3(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty logs_bucket before terraform destroy
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/test/terraform_aws_logs_test.go
+++ b/test/terraform_aws_logs_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
@@ -19,8 +18,9 @@ func TestTerraformAwsLogs(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/simple/",
 		Vars: map[string]interface{}{
-			"region":    awsRegion,
-			"test_name": testName,
+			"region":        awsRegion,
+			"test_name":     testName,
+			"force_destroy": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -28,7 +28,5 @@ func TestTerraformAwsLogs(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	// Empty logs_bucket before terraform destroy
-	defer aws.EmptyS3Bucket(t, awsRegion, testName)
 	terraform.InitAndApply(t, terraformOptions)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "s3_log_bucket_retention" {
 }
 
 variable "s3_bucket_acl" {
-  description = "Set bucket ACL per [AWS S3 Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) list."
+  description = "Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list."
   default     = "log-delivery-write"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -141,3 +141,9 @@ variable "nlb_accounts" {
   type        = list(string)
 }
 
+variable "force_destroy" {
+  description = "A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error."
+  default     = false
+  type        = bool
+}
+


### PR DESCRIPTION
Adds force_destroy bool, defaults to false

In the scenario where during a terraform destroy you want to delete a bucket that isn't empty, force_destroy = true allows a bucket to be deleted even if objects exist in the bucket. These objects are not recoverable! The bool defaults to false.

---

Commits on Jan 13, 2020
@dynamike
dynamike
Update CircleCI image and pre-commit to use new version of terraform-… …
2f1b028
…docs
@dynamike
dynamike
go mod tidy
140d2a4
@dynamike
dynamike
Merge pull request trussworks#40 from trussworks/mk-terraform-docs-up… …
31161f5
…date

Update CircleCI image and pre-commit to use new version of terraform-docs
- dependabot-preview - Bump github.com/gruntwork-io/terratest from 0.23.0 to 0.23.3 Bumps [github.com/gruntwork-io/terratest](https://github.com/gruntwork-io/terratest) from 0.23.0 to 0.23.3. - 61b43d2
- [Release notes](https://github.com/gruntwork-io/terratest/releases)
- [Commits](gruntwork-io/terratest@v0.23.0...v0.23.3)
Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

#### Commits on Jan 22, 2020
- esacteksab - initial commit -- buckets get deleted. Race condition still exists - d828bbf

#### Commits on Jan 23, 2020
- esacteksab - these need to not exist, this was the 'race condition' -- it was trying to delete the bucket twice. Missed in the first pass of cleanup.  -9e5f6c3
- esacteksab - Merge pull request trussworks#42 from trussworks/barry-force-delete Adds force_destroy bool, default false. - 78b35bd
